### PR TITLE
Fix headers and sessions for PHP 8

### DIFF
--- a/php/admin/home.php
+++ b/php/admin/home.php
@@ -1,7 +1,10 @@
 <?php
-if (!isset($_SESSION['loggedin']) and $_SESSION['loggedin'] != TRUE){
-    header("location: /login");
-    die("not loggedin");
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] != true) {
+    header('Location: /login');
+    exit('not loggedin');
 }
 require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
 require_once ("{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php");

--- a/php/admin/users.php
+++ b/php/admin/users.php
@@ -1,7 +1,10 @@
 <?php
-if (!isset($_SESSION['loggedin']) and $_SESSION['loggedin'] != TRUE){
-    header("location: /login");
-    die("not loggedin");
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] != true) {
+    header('Location: /login');
+    exit('not loggedin');
 }
 
 require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");

--- a/php/api/admin/getCaseFilter.php
+++ b/php/api/admin/getCaseFilter.php
@@ -131,6 +131,7 @@
             echo "<h3 class='text-center text-danger' dir='rtl'>لا توجد بيانات لعرضها.</h3>";
         }
 
-    }else{
+    } else {
         header('Location: /error');
+        exit();
     }

--- a/php/api/admin/getCaseSearch.php
+++ b/php/api/admin/getCaseSearch.php
@@ -131,6 +131,7 @@
             echo "<h3 class='text-center text-danger' dir='rtl'>لا توجد بيانات لعرضها.</h3>";
         }
 
-    }else{
+    } else {
         header('Location: /error');
+        exit();
     }

--- a/php/api/admin/setCase.php
+++ b/php/api/admin/setCase.php
@@ -19,6 +19,7 @@
 
             echo "<h3 class='text-center text-danger' dir='rtl'>حدث خطء في إرسال البيانات</h3>";
         }
-    }else{
+    } else {
         header('Location: /error');
+        exit();
     }

--- a/php/api/getCase.php
+++ b/php/api/getCase.php
@@ -69,12 +69,14 @@
 
 
 
-        }else{
+        } else {
             header('Location: /error');
+            exit();
         }
 
-    }else{
+    } else {
         header('Location: /error');
+        exit();
     }
 
     function getFirst($conn, $type, $difficulty){

--- a/php/api/login/login.php
+++ b/php/api/login/login.php
@@ -5,9 +5,9 @@ if(!isset($_SESSION))
 }
 else{
 
-    if(isset($_SESSION['loggedin']) && $_SESSION['loggedin'] == true)
-    {
-        header("location: /dashboard");
+    if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] == true) {
+        header('Location: /dashboard');
+        exit();
     }
 
 }
@@ -53,31 +53,36 @@ if ($_SERVER["REQUEST_METHOD"] == "POST")
                 $_SESSION['name'] = $name;
                 $_SESSION['user'] = $id;
 
-                header("location: /dashboard");
-                echo "Login successful.";
+                header('Location: /dashboard');
+                echo 'Login successful.';
+                exit();
 
             }
             else
             {
-                header("location: /login");
-                echo "Data input does not match.";
+                header('Location: /login');
+                echo 'Data input does not match.';
+                exit();
             }
         }
         else {
-            header("location: /login");
-            echo "Data input does not match.";
+            header('Location: /login');
+            echo 'Data input does not match.';
+            exit();
         }
 
     }
     else
     {
-        header("location: /login");
-        echo "No Data Send";
+        header('Location: /login');
+        echo 'No Data Send';
+        exit();
     }
 }
 else
 {
-    header("location: /404");
-    echo "404";
+    header('Location: /404');
+    echo '404';
+    exit();
 }
 ?>

--- a/php/api/logout.php
+++ b/php/api/logout.php
@@ -1,4 +1,9 @@
 <?php
+// Ensure the session is started before destroying it
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
 session_destroy();
-header("location: /login");
+header('Location: /login');
+exit();


### PR DESCRIPTION
## Summary
- handle session start and redirect headers consistently
- add Location header exits for error handling in admin API
- fix login and logout redirects

## Testing
- `grep -R "header('Location" -n php`

------
https://chatgpt.com/codex/tasks/task_e_685c46eefb888322b88a22226b40fba1