### PR TITLE
Fix path separators for server portability

### DIFF
--- a/php/admin/home.php
+++ b/php/admin/home.php
@@ -6,8 +6,8 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] != true) {
     header('Location: /login');
     exit('not loggedin');
 }
-require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
-require_once ("{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php");
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
+require_once ("{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php");
 $cases = new Case_();
 ?>
 <!DOCTYPE html>

--- a/php/admin/users.php
+++ b/php/admin/users.php
@@ -7,8 +7,8 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] != true) {
     exit('not loggedin');
 }
 
-require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
-require_once ("{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php");
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
+require_once ("{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php");
 
 ?>
 <!DOCTYPE html>

--- a/php/api/admin/case_adv/getEditPoint.php
+++ b/php/api/admin/case_adv/getEditPoint.php
@@ -1,6 +1,6 @@
 <?php
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
-    include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
+    include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
     if($_SERVER['REQUEST_METHOD'] === 'POST')
     {

--- a/php/api/admin/edit-case.php
+++ b/php/api/admin/edit-case.php
@@ -16,8 +16,8 @@
         </div>
 
         <?php
-            require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
-            include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+            require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
+            include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
             if($_SERVER['REQUEST_METHOD'] === 'POST')
             {

--- a/php/api/admin/getCase.php
+++ b/php/api/admin/getCase.php
@@ -1,6 +1,6 @@
 <?php
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
-    include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
+    include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
     $cases = new Case_();
 

--- a/php/api/admin/getCaseFilter.php
+++ b/php/api/admin/getCaseFilter.php
@@ -1,6 +1,6 @@
 <?php
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
-    include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
+    include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
     if($_SERVER['REQUEST_METHOD'] === 'POST'){
 

--- a/php/api/admin/showCase.php
+++ b/php/api/admin/showCase.php
@@ -1,6 +1,6 @@
 <?php
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
-    include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
+    include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
     $cases = new Case_();
 

--- a/php/api/csv_setCase.php
+++ b/php/api/csv_setCase.php
@@ -1,11 +1,11 @@
 <?php
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
     include "conn.php";
 
     $cases = new Case_();
 
 
-    $file_path = "{$_SERVER['DOCUMENT_ROOT']}\php\_files\data.csv";
+    $file_path = "{$_SERVER['DOCUMENT_ROOT']}/php/_files/data.csv";
     // Read a CSV file
     $handle = fopen($file_path, "r");
 

--- a/php/api/deleteUser.php
+++ b/php/api/deleteUser.php
@@ -1,5 +1,5 @@
 <?php
-require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\User.php");
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
 include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
 if($_SERVER['REQUEST_METHOD'] === 'POST'){

--- a/php/api/editUser.php
+++ b/php/api/editUser.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\User.php");
-require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\PasswordHash.php");
-include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/PasswordHash.php");
+include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
 
 $passw = new PasswordHash(8,"TRUE");

--- a/php/api/getCase.php
+++ b/php/api/getCase.php
@@ -1,5 +1,5 @@
 <?php
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
     include "conn.php";
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/php/api/getUsers.php
+++ b/php/api/getUsers.php
@@ -2,8 +2,8 @@
 
 if (isset($_SESSION['loggedin']) and $_SESSION['loggedin'] == TRUE){
 
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\User.php");
-    include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
+    include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
     $user = new User();
 

--- a/php/api/logCase.php
+++ b/php/api/logCase.php
@@ -1,6 +1,6 @@
 <?php
 
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
     include "conn.php";
 
     recLog($conn,$_POST);

--- a/php/api/login/edit-user.php
+++ b/php/api/login/edit-user.php
@@ -1,6 +1,6 @@
 <?php
-require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\User.php");
-include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
+include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
 if($_SERVER['REQUEST_METHOD'] === 'POST'){
 

--- a/php/api/login/login.php
+++ b/php/api/login/login.php
@@ -14,9 +14,9 @@ else{
 
 if ($_SERVER["REQUEST_METHOD"] == "POST")
 {
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\User.php");
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\PasswordHash.php");
-    include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/PasswordHash.php");
+    include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
 
     if(isset($_POST['password']) && isset($_POST['username']))

--- a/php/api/login/newUser.php
+++ b/php/api/login/newUser.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\User.php");
-require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\PasswordHash.php");
-include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/PasswordHash.php");
+include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
 
     $passw = new PasswordHash(8,"TRUE");

--- a/php/public/index.php
+++ b/php/public/index.php
@@ -1,6 +1,6 @@
 <?php
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\Case_.php");
-    require_once ("{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php");
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/Case_.php");
+    require_once ("{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php");
 
     $cases = new Case_();
 ?>

--- a/php/public/ss
+++ b/php/public/ss
@@ -484,9 +484,9 @@ if(!empty($_POST)){
 <?php
     /*var_dump(session_start());*/
 
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\User.php");
-    require_once("{$_SERVER['DOCUMENT_ROOT']}\php\Class\PasswordHash.php");
-    include "{$_SERVER['DOCUMENT_ROOT']}\php\api\conn.php";
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
+    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/PasswordHash.php");
+    include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
 
 


### PR DESCRIPTION
## Summary
- use forward slashes with `$_SERVER['DOCUMENT_ROOT']` in all PHP includes

## Testing
- `php -l php/public/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4919ee2883229c825cdc505aac4c