### PR TITLE
Add state column to users table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Case Bank
+
+This project provides a simple PHP application to manage cases and users. The `sql` folder contains example SQL scripts for setting up the database.
+
+## Database Setup
+
+Use one of the provided SQL dumps to create the schema:
+
+```sh
+mysql -u <user> -p < database_name > < sql/case_v1.sql
+```
+
+or
+
+```sh
+mysql -u <user> -p < database_name > < "sql/case_ v2.sql"
+```
+
+Both versions now include a `state` column in the `users` table:
+
+```sql
+state TINYINT NOT NULL DEFAULT 1
+```
+
+For existing databases run the migration in `sql/migrations/add_state_column.sql` to add the column:
+
+```sh
+mysql -u <user> -p < database_name > < sql/migrations/add_state_column.sql
+```

--- a/sql/case_ v2.sql
+++ b/sql/case_ v2.sql
@@ -244,6 +244,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `password` varchar(150) DEFAULT NULL,
   `profile_pic` varchar(300) NOT NULL,
   `type` int(11) NOT NULL,
+  `state` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 COMMIT;

--- a/sql/case_v1.sql
+++ b/sql/case_v1.sql
@@ -212,6 +212,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `password` varchar(150) DEFAULT NULL,
   `profile_pic` varchar(300) NOT NULL,
   `type` int(11) NOT NULL,
+  `state` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 COMMIT;

--- a/sql/migrations/add_state_column.sql
+++ b/sql/migrations/add_state_column.sql
@@ -1,0 +1,2 @@
+-- Migration script to add `state` column to existing `users` table
+ALTER TABLE `users` ADD COLUMN `state` TINYINT NOT NULL DEFAULT 1 AFTER `type`;


### PR DESCRIPTION
## Summary
- add `state` column to users table in SQL schemas
- provide migration script for existing databases
- document updated database setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c4c98e3fc8322a56064d8e2d5d37a