### PR TITLE
Use Eloquent in user API scripts

### DIFF
--- a/php/api/deleteUser.php
+++ b/php/api/deleteUser.php
@@ -1,23 +1,17 @@
 <?php
-require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
-include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
+use App\Models\UserModel;
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/bootstrap.php");
 
 if($_SERVER['REQUEST_METHOD'] === 'POST'){
 
     if(!empty($_POST))
     {
-        $user = new User();
-
-        $count =  $user->getCount($conn);
-
-        foreach ($count as $cn){
-            $number = $cn['nm'];
-        }
+        $number = UserModel::count();
 
         if ($number > 1){
 
-            $result = $user->deletUser($conn,$_POST["user"]);
-            echo $result;
+            $result = UserModel::destroy($_POST["user"]);
+            echo $result ? "1" : "0";
 
         }else{
 

--- a/php/api/editUser.php
+++ b/php/api/editUser.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
+use App\Models\UserModel;
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/bootstrap.php");
 require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/PasswordHash.php");
-include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
 
 $passw = new PasswordHash(8,"TRUE");
@@ -11,36 +11,29 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
 
     if(!empty($_POST))
     {
-        $user = new User();
-        if (empty($_POST['password'])){
+        $user = UserModel::find($_POST['id']);
+        if($user){
+            $user->name = $_POST['name'];
+            $user->state = $_POST['state'];
 
-            if($user->editUser($conn,$_POST)){
-
-                echo "نجحة عملة تحيث البيانات.";
-
-            }else{
-
-                echo "هناك مشكلة في عملية تحديث البيانات.";
+            if (!empty($_POST['password'])){
+                if (strlen($_POST['password']) > 8){
+                    $password = $passw->HashPassword($_POST['password']);
+                    $user->password = $password;
+                }else{
+                    echo "كلمة المرور يجب أن تكون تحتوي على 8 خانات أو أكبر.";
+                    return;
+                }
             }
 
-        }
-        else{
-            if (strlen($_POST['password']) > 8){
-
-                $password = $_POST['password'];
-
-                $password = $passw->HashPassword($password);
-
-                if($user->editPass($conn,$_POST,$password)){
-
+            if($user->save()){
+                if (!empty($_POST['password'])){
                     echo "تم تحديث كلمة المرور بنجاح.";
-
                 }else{
-
-                    echo "هناك خطء في عملية تحديث كلمة المرور.";
+                    echo "نجحة عملة تحيث البيانات.";
                 }
             }else{
-                echo "كلمة المرور يجب أن تكون تحتوي على 8 خانات أو أكبر.";
+                echo "هناك مشكلة في عملية تحديث البيانات.";
             }
         }
     }

--- a/php/api/getUsers.php
+++ b/php/api/getUsers.php
@@ -1,16 +1,13 @@
 <?php
+use App\Models\UserModel;
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/bootstrap.php");
 
 if (isset($_SESSION['loggedin']) and $_SESSION['loggedin'] == TRUE){
 
-    require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
-    include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
-
-    $user = new User();
-
-    $result = $user->getUsers($conn);
+    $result = UserModel::all();
 
     foreach ($result as $user_){
-        if($user_["state"] == 1){
+        if($user_->state == 1){
             $state = "مفعل";
         }else{
             $state = "غير مفعل";
@@ -23,17 +20,17 @@ if (isset($_SESSION['loggedin']) and $_SESSION['loggedin'] == TRUE){
                             </span>
                             <div class=" w-100 ps-2 pe-4 pt-1" >
                                 <p class="">
-                                    '.$user_["name"].'
+                                    '.$user_->name.'
                                 </p>
 
                                 <div  class="d-flex justify-content-between align-items-baseline">
                                     <p class="badge bg-orange text-end">
                                         '.$state.'
                                     </p>
-                                    <button data-id="'.$user_["id"].'" class="edit-btn btn-font btn btn-light btn-sm me-1">
+                                    <button data-id="'.$user_->id.'" class="edit-btn btn-font btn btn-light btn-sm me-1">
                                         <i class="bi bi-pencil-square"></i>
                                     </button>
-                                    <button data-id="'.$user_["id"].'" class="delete-btn btn-font btn btn-light btn-sm me-1">
+                                    <button data-id="'.$user_->id.'" class="delete-btn btn-font btn btn-light btn-sm me-1">
                                         <i class="bi bi-trash"></i>
                                     </button>
                                 </div>

--- a/php/api/login/edit-user.php
+++ b/php/api/login/edit-user.php
@@ -1,23 +1,17 @@
 <?php
-require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
-include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
+use App\Models\UserModel;
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/bootstrap.php");
 
 if($_SERVER['REQUEST_METHOD'] === 'POST'){
 
     if(!empty($_POST))
     {
-        $user = new User();
-
-        $resulte = $user->getUser_($conn, $_POST["user_id"]);
-        if (!empty($resulte)){
-
-            foreach ($resulte as $use){
-
-                $id = $use["id"];
-                $name = $use["name"];
-                $email = $use["email"];
-                $state = $use["state"];
-            }
+        $use = UserModel::find($_POST["user_id"]);
+        if ($use){
+            $id = $use->id;
+            $name = $use->name;
+            $email = $use->email;
+            $state = $use->state;
         }else{
             echo "<h1>فارغ</h1>";
         }

--- a/php/api/login/newUser.php
+++ b/php/api/login/newUser.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/User.php");
+use App\Models\UserModel;
+require_once("{$_SERVER['DOCUMENT_ROOT']}/php/bootstrap.php");
 require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/PasswordHash.php");
-include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
 
     $passw = new PasswordHash(8,"TRUE");
@@ -11,18 +11,18 @@ include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
         if(!empty($_POST))
         {
-            $user = new User();
+            $password = $passw->HashPassword($_POST['password']);
 
-            $password = $_POST['password'];
+            $user = UserModel::create([
+                'name' => $_POST['name'],
+                'email' => $_POST['email'],
+                'password' => $password,
+                'state' => 1
+            ]);
 
-            $password = $passw->HashPassword($password);
-
-            if($user->setUser($conn,$_POST,$password)){
-
+            if($user){
                 echo "true";
-
             }else{
-
                 echo "false";
             }
         }


### PR DESCRIPTION
## Summary
- remove old PDO usage from user management scripts
- use `UserModel` and Eloquent ORM for CRUD operations
- drop conn.php references

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8bc74dc483228e5a7e88eec3dc6d