### PR TITLE
Fix stylesheet link path in 404 page

### DIFF
--- a/error/404.html
+++ b/error/404.html
@@ -14,7 +14,7 @@
 	<link href="https://fonts.googleapis.com/css?family=Titillium+Web:700,900" rel="stylesheet">
 
 	<!-- Custom stlylesheet -->
-	<link type="text/css" rel="stylesheet" href="../../../../Users/monsef/Downloads/Compressed/colorlib-error-404-1/colorlib-error-404-1/css/style.css" />
+        <link type="text/css" rel="stylesheet" href="../assets/style.css" />
 
 	<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
 	<!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
## Summary
- update stylesheet link in the error page to use repo assets directory

## Testing
- `composer validate --no-check-all` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c8d20a9408322b5d862b78a27e0bc