### PR TITLE
Fix login script includes

### DIFF
--- a/php/api/login/login.php
+++ b/php/api/login/login.php
@@ -18,7 +18,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST")
 {
     require_once("{$_SERVER['DOCUMENT_ROOT']}/php/bootstrap.php");
     require_once("{$_SERVER['DOCUMENT_ROOT']}/php/Class/PasswordHash.php");
-    include "{$_SERVER['DOCUMENT_ROOT']}/php/api/conn.php";
 
 
     if(isset($_POST['password']) && isset($_POST['username']))


### PR DESCRIPTION
## Summary
- remove unused legacy database include from login

## Testing
- `php -l php/api/login/login.php`
- `composer --no-interaction install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c8de062fc8322a2f90639f01de3a4