### PR TITLE
Add Tailwind build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ vendor/
 
 # Ignore IDE directories
 .idea/
+
+# Ignore compiled assets
+assets/dist/*
+!assets/dist/.gitkeep

--- a/assets/src/tailwind.css
+++ b/assets/src/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "description": "Case Bank helper scripts",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tailwindcss -i ./assets/src/tailwind.css -o ./assets/dist/tailwind.css --postcss"
   },
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.2"
+  }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./php/**/*.{php,html}",
+    "./*.{php,html}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind build with PostCSS
- create Tailwind and PostCSS configs
- add starter CSS for Tailwind
- ignore compiled assets

## Testing
- `npm run build` *(fails: tailwindcss not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d2407d7848322bd7f633f548104ed